### PR TITLE
[GITHUB-3] Fixes tsc clocksource on T3s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,16 @@ language: python
 python:
   - 2.7
 
+branches:
+  only:
+    - develop
+    - master
+
 env:
-  - ANSIBLE_INSTALL_VERSION=2.2.3.0
-  - ANSIBLE_INSTALL_VERSION=2.3.3.0
-  - ANSIBLE_INSTALL_VERSION=2.4.3.0
+  - ANSIBLE_INSTALL_VERSION=2.4.6.0
+  - ANSIBLE_INSTALL_VERSION=2.5.11
+  - ANSIBLE_INSTALL_VERSION=2.6.7
+  - ANSIBLE_INSTALL_VERSION=2.7.1
 
 services:
   - docker

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ANSIBLE_INSTALL_VERSION ?= 2.4.2.0
+ANSIBLE_INSTALL_VERSION ?= 2.6.7
 PATH := $(PWD)/.venv_ansible$(ANSIBLE_INSTALL_VERSION)/bin:$(shell printenv PATH)
 SHELL := env PATH=$(PATH) /bin/bash
 

--- a/files/clocksource-setup.systemd
+++ b/files/clocksource-setup.systemd
@@ -1,0 +1,9 @@
+[Unit]
+Description=Enable TSC clocksource
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'echo tsc > /sys/devices/system/clocksource/clocksource0/current_clocksource'

--- a/files/clocksource-setup.sysv
+++ b/files/clocksource-setup.sysv
@@ -1,0 +1,37 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          clocksource-setup
+# Required-Start:    mountkernfs
+# Should-Start:      udev module-init-tools cpufrequtils
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: Enable TSC clocksource
+# Description:       Enable TSC clocksource
+### END INIT INFO
+
+NAME=$( basename $0 )
+
+NAME=clocksource-setup
+DESC="Sets Cloucksource on boot"
+
+if [ $( id -u ) -ne 0 ]; then
+    echo "You need root privileges to run this script"
+    exit 1
+fi
+
+. /lib/lsb/init-functions
+
+case "$1" in
+    start|restart|force-reload)
+        echo "tsc" > /sys/devices/system/clocksource/clocksource0/current_clocksource
+        ;;
+    stop)
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|force-reload|restart}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: restart sysfsutils
+- name: start clocksource-setup
   become: yes
   service:
-    name: sysfsutils
-    state: restarted
+    name: clocksource-setup
+    state: started

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,13 +3,14 @@
 galaxy_info:
   description: Applies EC2 performance enhancements
   license: MIT
-  min_ansible_version: 2.2
-  min_ansible_container_version: 2.2
+  min_ansible_version: 2.4
+  min_ansible_container_version: 2.4
   platforms:
     - name: Ubuntu
       versions:
         - trusty
         - xenial
+        - bionic
   galaxy_tags:
     - cloud
     - ec2

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,13 +1,8 @@
 ---
 
-# The default driver for molecule is docker, but other backend are supported by molecule.
-# See https://molecule.readthedocs.io/en/latest/configuration.html#driver for details.
 driver:
   name: docker
 
-# The platforms on which to test your role.  Groups can be created to spin up multiple instances per test.
-# See https://molecule.readthedocs.io/en/latest/configuration.html#platforms for details.
-# NOTE: Different drivers (see above) may have different configuration options.
 platforms:
   - name: aws_ec2_perf-trusty
     image: ubuntu:trusty
@@ -15,18 +10,20 @@ platforms:
   - name: aws_ec2_perf-xenial
     image: ubuntu:xenial
     privileged: yes
+  - name: aws_ec2_perf-bionic
+    image: solita/ubuntu-systemd:bionic
+    command: /sbin/init
+    capabilities:
+      - SYS_ADMIN
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
-# Ansible is the only supported provisioner.  Configure Ansible options here, change the linter for Ansible playbooks,
-# or modify the playbooks run for the various molecule tasks.
-# See https://molecule.readthedocs.io/en/latest/configuration.html#provisioner for details.
 provisioner:
   name: ansible
   lint:
     name: ansible-lint
 
-# Configures the YAML linter; currently, only support for yamllint is implemented.  Configuration options for
-# yamllint (https://yamllint.readthedocs.io/en/latest/configuration.html) can be specified.
-# See https://molecule.readthedocs.io/en/latest/configuration.html#lint for details.
 lint:
   name: yamllint
   options:
@@ -38,32 +35,12 @@ lint:
           max: 159
         truthy: disable
 
-# Dependency resolution is by default handled through Ansible Galaxy, but support for gilt (http://gilt.readthedocs.io/)
-# is available.  See https://molecule.readthedocs.io/en/latest/configuration.html#dependency for details.
 dependency:
   name: galaxy
 
-# Every role to be tested via molecule requires at least one scenario.  Change the tasks executed for molecule
-# commands here, if necessary.
-# See https://molecule.readthedocs.io/en/latest/configuration.html#scenario for details.
 scenario:
   name: default
-  # The test_sequence can be removed once molecule reaches version 2.6.  See
-  # https://github.com/metacloud/molecule/issues/1057 for reason.
-  test_sequence:
-    - lint
-    - dependency
-    - syntax
-    - create
-    - prepare
-    - converge
-    - idempotence
-    - side_effect
-    - verify
 
-# The default verifier is testinfra, but goss is supported as well.  Configure the verifier, verifier options, and,
-# if using testinfra, linter and linter options here.
-# See https://molecule.readthedocs.io/en/latest/configuration.html#verifier for details.
 verifier:
   name: testinfra
   lint:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -14,5 +14,4 @@
     - role: aws_ec2_perf
       sansible_aws_ec2_perf_clocksource_enabled: yes
       sansible_aws_ec2_perf_filesystem_enabled: yes
-      sansible_aws_ec2_perf_huge_pages_enabled: yes
       sansible_aws_ec2_perf_virtual_mem_enabled: yes

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -2,5 +2,20 @@
 
 - name: Prepare
   hosts: all
-  gather_facts: false
-  tasks: []
+  gather_facts: no
+
+  tasks:
+    - name: Install Python for Ansible
+      become: yes
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-zipstream)
+      changed_when: no
+
+    - name: Install apt-transport-https, lsb-release, net-tools
+      become: yes
+      apt:
+        name: "{{ item }}"
+        update_cache: yes
+      with_items:
+        - apt-transport-https
+        - lsb-release
+        - net-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-docker-py
-molecule
+docker
+molecule==2.19.0
+pytest==3.9.3

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,12 +1,5 @@
 ---
 
-- name: Install sysfsutils if required
-  become: yes
-  apt:
-    name: sysfsutils
-  when: sansible_aws_ec2_perf_huge_pages_enabled
-    or sansible_aws_ec2_perf_clocksource_enabled
-
 - name: Setup sysctl Virtual Memory performance settings
   become: yes
   sysctl:
@@ -79,12 +72,47 @@
     - name: "net.ipv4.tcp_abort_on_overflow"
       value: 1
 
-- name: Switch clocksource to tsc to fix Trusty Xen Hypervisor issue
+- name: Create Clocksource Setup service for SysV
   become: yes
   copy:
-    content: "devices/system/clocksource/clocksource0/current_clocksource = tsc\n"
-    dest: /etc/sysfs.d/clocksource.conf
-    mode: 0644
-  when: sansible_aws_ec2_perf_clocksource_enabled
+    dest: /etc/init.d/clocksource-setup
+    owner: root
+    mode: 0755
+    src: clocksource-setup.sysv
+  when:
+    - sansible_aws_ec2_perf_clocksource_enabled
+    - ansible_service_mgr != "systemd"
   notify:
-    - restart sysfsutils
+    - start clocksource-setup
+
+- name: Ensure Clocksource Setup service is enabled for SysV
+  become: yes
+  service:
+    enabled: yes
+    name: clocksource-setup
+  when:
+    - sansible_aws_ec2_perf_clocksource_enabled
+    - ansible_service_mgr != "systemd"
+
+- name: Create Clocksource Setup service for SystemD
+  become: yes
+  copy:
+    dest: /lib/systemd/system/clocksource-setup.service
+    owner: root
+    mode: 0644
+    src: clocksource-setup.systemd
+  when:
+    - sansible_aws_ec2_perf_clocksource_enabled
+    - ansible_service_mgr == "systemd"
+  notify:
+    - start clocksource-setup
+
+- name: Ensure Clocksource Setup service is enabled for SystemD
+  become: yes
+  systemd:
+    daemon_reload: yes
+    enabled: yes
+    name: clocksource-setup
+  when:
+    - sansible_aws_ec2_perf_clocksource_enabled
+    - ansible_service_mgr == "systemd"


### PR DESCRIPTION
Switches to a service for setting the clocksource to tsc,
sysfsutils doesn't seem to have any effect on T3 instances where
the clocksource gets set to kvm-clock.